### PR TITLE
Add unit tests to provide coverage for disconnect messages

### DIFF
--- a/src/test/java/org/thingsboard/gateway/extensions/kinesis/KinesisTest.java
+++ b/src/test/java/org/thingsboard/gateway/extensions/kinesis/KinesisTest.java
@@ -67,6 +67,9 @@ public class KinesisTest {
     private static final String VARIABLES_MESSAGE_PATH = makePath(DEVICES_PATH, VARIABLES_PATH);
     private static final String EVENTS_MESSAGE_PATH = makePath(DEVICES_PATH, EVENTS_PATH);
 
+    private static final String EXPECTED_OID = "1.3.6.1.4.1.32473.1.2";
+    private static final String EXPECTED_TYPE = "disconnect";
+
 
     @Mock
     private GatewayService gateway;
@@ -314,4 +317,51 @@ public class KinesisTest {
 
         testProcessBody(body);
     }
+
+
+    @Test
+    public void shouldCallProcessBodyWithServersDisconnectNullOidNullType() {
+        String body = makeDisconnectBody(null, null);
+
+        testProcessBody(body);
+    }
+
+
+    private String makeDisconnectBody(String oid, String type) {
+        return  "{ \"oid\": \"" + oid + "\", \"type\": \"" + type + "\"  }";
+    }
+
+
+    @Test
+    public void shouldCallProcessBodyWithServersDisconnectExpectedOidNullType() {
+        String body = makeDisconnectBody(EXPECTED_OID, null);
+
+        testProcessBody(body);
+    }
+
+
+    @Test
+    public void shouldCallProcessBodyWithServersDisconnectExpectedOidExpectedType() {
+        String body = makeDisconnectBody(EXPECTED_OID, EXPECTED_TYPE);
+
+        testProcessBody(body);
+    }
+
+
+    @Test
+    public void shouldCallProcessBodyWithServersDisconnectExpectedOidInvalidType() {
+        String body = makeDisconnectBody(EXPECTED_OID, "foobar");
+
+        testProcessBody(body);
+    }
+
+
+    @Test
+    public void shouldCallProcessBodyWithServersDisconnectInvalidOidNullType() {
+        String body = makeDisconnectBody("foobar", null);
+
+        testProcessBody(body);
+    }
+
+
 }


### PR DESCRIPTION
As of this commit, current coverage for the Kinesis class stands
at 92% instruction coverage and 88% branch coverage. Accordingly,
there will be no additional unit tests added for the Kinesis class
until migrating from version 1.8.5 the Amazon Kinesis Client Library
to version 2.x.