### PR TITLE
Update Docker version in Makefile from 1.2.1 to 2.2.1

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,4 +1,4 @@
-VERSION=1.2.1
+VERSION=2.2.1
 PROJECT=thingsboard
 APP=gateway
 


### PR DESCRIPTION
Test case:

1. `docker images | rg 'thingsboard/gateway'`
Notice either no results or an image with version != 2.2.1
2. `cd <github-root>/thingsboard-gateway/docker`
3. `make`
4.  `docker images | rg 'thingsboard/gateway'`
Should see results similar to:

`thingsboard/gateway             2.2.1               f75b2ecaca90        15 hours ago        480MB`
`thingsboard/gateway             latest              f75b2ecaca90        15 hours ago        480MB`