### PR TITLE
Update docker image version from 1.2.1 to 2.2.1 in docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,7 +18,7 @@ version: '2'
 
 services:
   tb-gateway:
-    image: "thingsboard/gateway:1.2.1"
+    image: "thingsboard/gateway:2.2.1"
     environment:
       - GATEWAY_ACCESS_TOKEN=${GATEWAY_ACCESS_TOKEN}
       - GATEWAY_HOST=${GATEWAY_HOST}


### PR DESCRIPTION
The `docker-compose.yml` needs to have the correct version of the Thingsboard Gateway Docker image specified.